### PR TITLE
Avoid "Can't call method "isa" on unblessed reference"

### DIFF
--- a/lib/Hash/Merge.pm
+++ b/lib/Hash/Merge.pm
@@ -3,6 +3,7 @@ package Hash::Merge;
 use strict;
 use warnings;
 use Carp;
+use Scalar::Utils qw( blessed );
 
 use base 'Exporter';
 use vars qw($VERSION @ISA @EXPORT_OK %EXPORT_TAGS $context);
@@ -97,7 +98,7 @@ $GLOBAL->{'clone'}    = 1;
 
 sub _get_obj {
     if ( my $type = ref $_[0] ) {
-        return shift() if $type eq __PACKAGE__ || eval { $_[0]->isa(__PACKAGE__) };
+        return shift() if $type eq __PACKAGE__ || (blessed $_[0] && $_[0]->isa(__PACKAGE__));
     }
 
     return $context;


### PR DESCRIPTION
Use Scalar::Util::blessed to test whether the arg is a reference
or not, before calling "isa" on it.  Blindly calling "isa" and
using eval to ignore the resulting error still triggers DIE
handlers when it does not need to.

This resolves:

    https://rt.cpan.org/Public/Bug/Display.html?id=55978