### PR TITLE
Avoid "Can't call method "isa" on unblessed reference"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+---
+install:
+  - cpanm --notest --skip-satisfied App::mymeta_requires
+  - perl Makefile.PL
+  - make manifest
+  - mymeta-requires --runtime --build --test --configure --develop --recommends --suggests | cpanm
+language: perl
+perl:
+  - "5.18"
+  - "5.16"
+  - "5.14"
+  - "5.12"
+  - "5.10"

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,6 +7,7 @@ use ExtUtils::MakeMaker;
 
 my %RUN_DEPS = (
                  'Clone' => 0,
+                 'Scalar::Util' => 0,
                );
 my %CONFIGURE_DEPS = (
                        'ExtUtils::MakeMaker' => 0,

--- a/lib/Hash/Merge.pm
+++ b/lib/Hash/Merge.pm
@@ -3,6 +3,7 @@ package Hash::Merge;
 use strict;
 use warnings;
 use Carp;
+use Scalar::Util qw( blessed );
 
 use base 'Exporter';
 use vars qw($VERSION @ISA @EXPORT_OK %EXPORT_TAGS $context);
@@ -97,7 +98,7 @@ $GLOBAL->{'clone'}    = 1;
 
 sub _get_obj {
     if ( my $type = ref $_[0] ) {
-        return shift() if $type eq __PACKAGE__ || eval { $_[0]->isa(__PACKAGE__) };
+        return shift() if $type eq __PACKAGE__ || (blessed $_[0] && $_[0]->isa(__PACKAGE__));
     }
 
     return $context;


### PR DESCRIPTION
Use Scalar::Util::blessed to test whether the arg is a reference
or not, before calling "isa" on it.  Blindly calling "isa" and
using eval to ignore the resulting error still triggers DIE
handlers when it does not need to.

This resolves:

```
https://rt.cpan.org/Public/Bug/Display.html?id=55978
```
