### PR TITLE
prevent a default Hash::Merge instance from creating memory leaks

### DIFF
--- a/t/inline/02-oo.t
+++ b/t/inline/02-oo.t
@@ -344,4 +344,13 @@ is_deeply($cp{oo}, {foo => {key => 'left'}}, 'Custom Precedent - Object on Objec
     main::ok($merged);
 }
 
+{
+    my $destroyed = 0;
+    no warnings 'once';
+    local *Hash::Merge::DESTROY = sub { $destroyed = 1 };
+    use warnings;
+    Hash::Merge->new;
+    ok $destroyed, "instance did not leak";
+}
+
 done_testing;


### PR DESCRIPTION
Fix for https://rt.cpan.org/Ticket/Display.html?id=132627